### PR TITLE
S3Path: mkdir() as no-op

### DIFF
--- a/src/smallmatter/pathlib.py
+++ b/src/smallmatter/pathlib.py
@@ -128,8 +128,8 @@ class S3Path(Path2):
         raise NotImplementedError()
 
     def mkdir(self, *args, **kwargs):
+        """No-op: no actual S3 prefix created, and no bucket created even if parents=True."""
         self._try_raise_closed()
-        raise NotImplementedError()
 
     def read_bytes(self, *args, **kwargs):
         """Read bytes from file."""


### PR DESCRIPTION
`S3Path.mkdir()` as no-op as opposed to throwing`NotImplementedException()`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
